### PR TITLE
Rolling back a version update due to beak

### DIFF
--- a/latest.yml
+++ b/latest.yml
@@ -1,7 +1,7 @@
 services:
   lrctl: 
     image: gcr.io/lrcollection/lrctl
-    version: 0.1.20
+    version: 0.1.18
   open-collector:  
     image: gcr.io/lrcollection/opencollector
     version: 0.1.17


### PR DESCRIPTION
Rolling back due to a change that broke the lrctl commands.