### PR TITLE
eventhub rollback to 0.1.5

### DIFF
--- a/latest.yml
+++ b/latest.yml
@@ -10,7 +10,7 @@ services:
     version: 0.3.0
   eventhubbeat:  
     image: gcr.io/lrcollection/beats/eventhubbeat
-    version: 2.0.0
+    version: 0.1.5
   gsbeat:
     image: gcr.io/lrcollection/beats/gsbeat
     version: 0.1.3


### PR DESCRIPTION
Eventhubbeat version rolled back to 0.1.5