### PR TITLE
lrctl script update to support oracle linux machines for init command

### DIFF
--- a/lrctl
+++ b/lrctl
@@ -259,13 +259,21 @@ ensureUserIsInDockerGroup() {
 
 # check if docker is installed on machine
 installDockerCE() {
-  curl -fsSL https://get.docker.com/ | sh
-  sudo systemctl start docker
-  sudo systemctl enable docker
-  # Disable exit on error so that we can capture the return status from ensureUserIsInDockerGroup.
-  set +e
-  ensureUserIsInDockerGroup
-  set -e
+    # Check if the distribution is Oracle
+    if [[ $(get_distribution) == "ol" ]]; then
+        echo "Installing docker for Oracle Linux"
+        dnf remove -y runc
+        dnf config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+        dnf install -y docker-ce --nobest
+    else
+        curl -fsSL https://get.docker.com/ | sh
+    fi
+    sudo systemctl start docker
+    sudo systemctl enable docker
+    # Disable exit on error so that we can capture the return status from ensureUserIsInDockerGroup.
+    set +e
+    ensureUserIsInDockerGroup
+    set -e
 }
 
 get_distribution() {


### PR DESCRIPTION
# What does this Change do?
This change will add support for Oracle Linux machines to install docker using .\lrctl init command

# Mention story/defects here
[ENG-29898]

# How was the change(s) implemented?
By updating the script to add condition and docker installation commands for Oracle Linux machines.

# Are these change(s) requires documentation updates
Yes, in below docs:
https://confluence.logrhythm.com/display/OCBeats/.Install+Oracle+Linux+8.7+v2023.04?src=contextnavpagetreemode
https://confluence.logrhythm.com/display/OCBeats/.Install+Oracle+Linux+9.1+v2023.04?src=contextnavpagetreemode

# How is these change(s) are tested?
By running script on Centos7, Oracle8 and Oracle 9 machine

[ENG-29898]: https://logrhythm.atlassian.net/browse/ENG-29898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ