### PR TITLE
Release2025.07 version changes

### DIFF
--- a/latest.yml
+++ b/latest.yml
@@ -1,7 +1,7 @@
 services:
   lrctl:
     image: release.exabeam.com/docker-local/logrhythm/collection/collection-release/lrctl
-    version: 6.5.20
+    version: 6.6.0
   open-collector:
     image: release.exabeam.com/docker-local/logrhythm/collection/collection-release/opencollector
     version: 5.6.20
@@ -22,7 +22,7 @@ services:
     version: 6.0.3
   sophoscentralbeat:
     image: release.exabeam.com/docker-local/logrhythm/collection/collection-release/beats/sophoscentralbeat
-    version: 6.0.3
+    version: 7.0.0
   gmtbeat:
     image: release.exabeam.com/docker-local/logrhythm/collection/collection-release/beats/gmtbeat
     version: 6.0.5
@@ -74,6 +74,9 @@ services:
   sentinelonebeat:
     image: release.exabeam.com/docker-local/logrhythm/collection/collection-release/beats/sentinelonebeat
     version: 6.0.1
+  mimecastsiembeat:
+    image: release.exabeam.com/docker-local/logrhythm/collection/collection-release/beats/mimecastsiembeat
+    version: 6.0.0
 utilities:
   lrjq:
     image: release.exabeam.com/docker-local/logrhythm/collection/collection-release/lrjq

--- a/lrctl
+++ b/lrctl
@@ -8,7 +8,7 @@ script_name=$(basename "${BASH_SOURCE[0]}")
 # === LRCTL VARIABLES ===
 
 lrctl_debug=0
-lrctl_version="6.5.19"
+lrctl_version="6.6.0"
 lrctl_image=""
 lrctl_new_shell_after_group_membership=1
 lrctl_docker_membership_return_code=255


### PR DESCRIPTION
This pull request updates the version numbers for several services and introduces a new service configuration.

Bumps lrctl version to 6.6.0
Updates sophoscentralbeat version from 6.0.3 to 7.0.0
Adds a new service entry for mimecastsiembeat with version 6.0.0