### PR TITLE
Update service versions in latest.yml

### DIFF
--- a/latest.yml
+++ b/latest.yml
@@ -1,7 +1,7 @@
 services:
   lrctl:
     image: release.exabeam.com/docker-local/logrhythm/collection/collection-release/lrctl
-    version: 6.6.4
+    version: 6.6.5
   open-collector:
     image: release.exabeam.com/docker-local/logrhythm/collection/collection-release/opencollector
     version: 5.6.20
@@ -43,7 +43,7 @@ services:
     version: 6.0.5
   kafkabeat:
     image: release.exabeam.com/docker-local/logrhythm/collection/collection-release/beats/kafkabeat
-    version: 6.0.7
+    version: 6.0.8
   qualysfimbeat:
     image: release.exabeam.com/docker-local/logrhythm/collection/collection-release/beats/qualysfimbeat
     version: 6.0.5
@@ -58,7 +58,7 @@ services:
     version: 6.0.3
   msgraphbeat:
     image: release.exabeam.com/docker-local/logrhythm/collection/collection-release/beats/msgraphbeat
-    version: 6.1.0
+    version: 6.1.1
   prismacloudbeat:
     image: release.exabeam.com/docker-local/logrhythm/collection/collection-release/beats/prismacloudbeat
     version: 6.0.4

--- a/lrctl
+++ b/lrctl
@@ -8,7 +8,7 @@ script_name=$(basename "${BASH_SOURCE[0]}")
 # === LRCTL VARIABLES ===
 
 lrctl_debug=0
-lrctl_version="6.6.4"
+lrctl_version="6.6.5"
 lrctl_image=""
 lrctl_new_shell_after_group_membership=1
 lrctl_docker_membership_return_code=255


### PR DESCRIPTION
This PR has changes for 2026.04.Patch1 and below are the updates.

msgraphbeat
Image: release.exabeam.com/docker-local/logrhythm/collection/collection-release/beats/msgraphbeat
Version: 6.1.1
kafkabeat
Image: release.exabeam.com/docker-local/logrhythm/collection/collection-release/beats/kafkabeat
Version: 6.0.8
lrctl
Image: release.exabeam.com/docker-local/logrhythm/collection/collection-release/lrctl
Version: 6.6.5